### PR TITLE
Image Upload Successful and remove .env from remote and ignore

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-VITE_BASE_URL="https://philip-clicking-programming-capacity.trycloudflare.com"
-

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env


### PR DESCRIPTION
Add .env to gitignore in terminal using the command below:
```terminal
echo '.env' >> .gitignore
```
Then remove the cached .env using the command below:
```terminal
git rm --cached .env
```